### PR TITLE
Update the URL of Pipenv documentation page

### DIFF
--- a/conf.d/pipenv.fish
+++ b/conf.d/pipenv.fish
@@ -29,8 +29,8 @@ if command -s pipenv > /dev/null
         end
     end
 else
-    function pipenv -d "http://docs.pipenv.org/en/latest/"
-        echo "Install http://docs.pipenv.org/en/latest/ to use this plugin." > /dev/stderr
+    function pipenv -d "https://pipenv.readthedocs.io/en/latest/"
+        echo "Install https://pipenv.readthedocs.io/en/latest/ to use this plugin." > /dev/stderr
         return 1
     end
 end


### PR DESCRIPTION
Hi, Pipenv Documentation page has moved to here:
https://pipenv.readthedocs.io/en/latest/

P.S. Thanks for useful fish config file! :)