### PR TITLE
Add another homebrew solution to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,13 @@ above error.
     The `000` preface is to ensure that, that script will be executed first before the others in config.d. You
     don't have to prefix the file with `000` it is abitrary. Just give it a name that places it at the to of the
     pile.
+
+3. Or assuming you also have [fish-pyenv](https://github.com/daenney/pyenv) you can add a universal variable to
+    your `fish_user_paths` following
+    [mhugbin](https://github.com/kennethreitz/fish-pipenv/issues/1#issuecomment-385206132):
+
+    ```fish
+    set -U fish_user_paths ~/.pyenv/shims $fish_user_paths
+    ```
     
  See [https://github.com/fisherman/pipenv/issues/1](url)

--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ above error.
     set -U fish_user_paths ~/.pyenv/shims $fish_user_paths
     ```
     
- See [https://github.com/fisherman/pipenv/issues/1](url)
+ See https://github.com/kennethreitz/fish-pipenv/issues/1

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Using [Fisher](https://github.com/jorgebucaran/fisher):
 
     $ fisher add kennethreitz/fish-pipenv
 
-Fisher is the only recommended Fish package manager. Use nothing else.
-
 ## Potential Issues
 ### Mac OS
 After installing pipenv, running the $ pipenv command may yield the following error

--- a/conf.d/pipenv.fish
+++ b/conf.d/pipenv.fish
@@ -19,7 +19,7 @@ if command -s pipenv > /dev/null
         if not test -n "$PIPENV_ACTIVE"
           if pipenv --venv >/dev/null 2>&1
             set -x __pipenv_fish_initial_pwd "$PWD"
-            pipenv shell --fancy
+            pipenv shell
             set -e __pipenv_fish_initial_pwd
             if test -n "$__pipenv_fish_final_pwd"
                 cd "$__pipenv_fish_final_pwd"

--- a/conf.d/pipenv.fish
+++ b/conf.d/pipenv.fish
@@ -19,7 +19,7 @@ if command -s pipenv > /dev/null
         if not test -n "$PIPENV_ACTIVE"
           if pipenv --venv >/dev/null 2>&1
             set -x __pipenv_fish_initial_pwd "$PWD"
-            pipenv shell
+            pipenv shell --fancy
             set -e __pipenv_fish_initial_pwd
             if test -n "$__pipenv_fish_final_pwd"
                 cd "$__pipenv_fish_final_pwd"


### PR DESCRIPTION
Just fixing the link to [issue 1](https://github.com/kennethreitz/fish-pipenv/issues/1) in README.md and adding the last solution suggested as option 3.

There may be a way to add it automatically using something like:
```fish
switch (uname)
case Darwin
    set -U fish_user_paths ~/.pyenv/shims $fish_user_paths
end
```
though if it can't be implemented without [pyenv-fisher](https://github.com/daenney/pyenv) maybe that's too much to require.